### PR TITLE
Connect function bug

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -14,5 +14,6 @@
 * Nathan Owens (@virtuallynathan)
 * Whitham Reeve (@wdreeveii)
 * Benjamin Thomas (@benjamin-thomas)
+* Ross Wilson (@schotlandzegtja)
 
 In alphabetical order of surname. In vim: highlight, then `!sort -k3`.

--- a/README.md
+++ b/README.md
@@ -33,23 +33,20 @@ GoSNMP has the following SNMP functions:
 * **BulkWalk** - retrieves a subtree of values using GETBULK.
 * **Set** (beta - currently supports Integers and OctetStrings)
 
-GoSNMP also has the following helper functions:
+GoSNMP has support for **receiving** traps; see the file
+**examples/trapserver.go** for usage.
+
+GoSNMP will have support for **sending** traps. Kripakaran Karlekar sent
+a patch May/2016; I haven't yet had time to explore or integrate his
+code, it's in the branch **traps2**.
+
+GoSNMP also has the following **helper** functions:
 
 * **ToBigInt** - treat returned values as `*big.Int`
 * **Partition** - facilitates dividing up large slices of OIDs
 
-GoSNMP has rudimentry support for *receiving* traps. This code needs work
-(pull request welcome) - see the branch **traps**. The developer
-[@jda](https://github.com/jda) says "I'm working on the best level of
-abstraction but I'm able to receive traps from a Cisco switch and
-Net-SNMP".
-
-In addition, *Kripakaran Karlekar* has just (May/2016) sent a
-diff for *sending* traps. I haven't yet had time to
-explore or integrate his code, it's in the branch **traps2**.
-
-**soniah/gosnmp** has diverged from **alouca/gosnmp** - your existing
-code will require modification:
+**soniah/gosnmp** has diverged _significantly_ from **alouca/gosnmp**.
+Your code will require modification in these (and other) locations:
 
 * the **Get** function has a different method signature
 * the **NewGoSNMP** function has been removed, use **Connect** instead
@@ -66,7 +63,7 @@ type Logger interface {
 }
 ```
 
-gosnmp is still under development, therefore API's may change and bugs
+GoSNMP is still under development, therefore API's may change and bugs
 will be squashed. Test Driven Development is used - you can help by
 sending packet captures (see Packet Captures below). There may be more
 than one branch on github. **master** is safe to pull from, other
@@ -148,6 +145,8 @@ Running this example gives the following output (from my printer):
 **examples/walkexample.go** demonstrates using `BulkWalk`.
 
 **examples/example3.go** demonstrates `SNMPv3`
+
+**examples/trapserver.go** demonstrates writing an SNMP v2c trap server
 
 Bugs
 ----

--- a/README.md
+++ b/README.md
@@ -5,10 +5,9 @@ gosnmp
 [![GoDoc](https://godoc.org/github.com/soniah/gosnmp?status.png)](http://godoc.org/github.com/soniah/gosnmp)
 https://github.com/soniah/gosnmp
 
-GoSNMP is an SNMP client library written fully in Go. Currently it
-provides GetRequest, GetNext, GetBulk, Walk (beta, see below), and
-SetRequest (beta, see below). It supports IPv4 and IPv6, using
-__SNMPv2c__ or __SNMPv3__.
+GoSNMP is an SNMP client library fully written in Go. It provides Get,
+GetNext, GetBulk, Walk, BulkWalk and Set. It supports IPv4 and IPv6,
+using __SNMPv2c__ or __SNMPv3__.
 
 About
 -----
@@ -21,6 +20,8 @@ these project collaborators:
 * Nathan Owens ([@virtuallynathan](https://github.com/virtuallynathan/))
 * Whitham Reeve ([@wdreeveii](https://github.com/wdreeveii/))
 
+Sonia Hamilton, sonia@snowfrog.net, http://www.snowfrog.net.
+
 Overview
 --------
 
@@ -31,16 +32,13 @@ GoSNMP has the following SNMP functions:
 * **GetBulk**
 * **Walk** - retrieves a subtree of values using GETNEXT.
 * **BulkWalk** - retrieves a subtree of values using GETBULK.
-* **Set** (beta - currently supports Integers and OctetStrings)
+* **Set** - supports Integers and OctetStrings
+* **SendTrap** - currently being integrated
 
-GoSNMP has support for **receiving** traps; see the file
+GoSNMP also has support for **receiving** traps; see the file
 **examples/trapserver.go** for usage.
 
-GoSNMP will have support for **sending** traps. Kripakaran Karlekar sent
-a patch May/2016; I haven't yet had time to explore or integrate his
-code, it's in the branch **traps2**.
-
-GoSNMP also has the following **helper** functions:
+GoSNMP has the following **helper** functions:
 
 * **ToBigInt** - treat returned values as `*big.Int`
 * **Partition** - facilitates dividing up large slices of OIDs
@@ -68,8 +66,6 @@ will be squashed. Test Driven Development is used - you can help by
 sending packet captures (see Packet Captures below). There may be more
 than one branch on github. **master** is safe to pull from, other
 branches unsafe as history may be rewritten.
-
-Sonia Hamilton, sonia@snowfrog.net, http://www.snowfrog.net.
 
 Installation
 ------------

--- a/examples/trapserver.go
+++ b/examples/trapserver.go
@@ -1,0 +1,57 @@
+// Copyright 2012-2016 The GoSNMP Authors. All rights reserved.  Use of this
+// source code is governed by a BSD-style license that can be found in the
+// LICENSE file.
+
+/*
+The developer of the trapserver code (https://github.com/jda) says "I'm working
+on the best level of abstraction but I'm able to receive traps from a Cisco
+switch and Net-SNMP".
+
+Pull requests welcome.
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	g "github.com/soniah/gosnmp"
+	"log"
+	"net"
+	"os"
+	"path/filepath"
+)
+
+func main() {
+	flag.Usage = func() {
+		fmt.Printf("Usage:\n")
+		fmt.Printf("   %s\n", filepath.Base(os.Args[0]))
+		flag.PrintDefaults()
+	}
+
+	params := g.Default
+	params.Logger = log.New(os.Stdout, "", 0)
+
+	tl := g.TrapListener{
+		OnNewTrap: myTrapHandler,
+		Params:    params,
+	}
+	err := tl.Listen("0.0.0.0:9162")
+	if err != nil {
+		log.Panicf("error in listen: %s", err)
+	}
+}
+
+func myTrapHandler(packet *g.SnmpPacket, addr *net.UDPAddr) {
+	log.Printf("got trapdata from %s\n", addr.IP)
+	for _, v := range packet.Variables {
+		switch v.Type {
+		case g.OctetString:
+			b := v.Value.([]byte)
+			fmt.Printf("OID: %s, string: %x\n", v.Name, b)
+
+		default:
+			log.Printf("trap: %+v\n", v)
+		}
+	}
+}

--- a/generic_e2e_test.go
+++ b/generic_e2e_test.go
@@ -131,6 +131,39 @@ func TestGenericBulkWalk(t *testing.T) {
 
 // Standard exception/error tests
 
+func TestMaxOids(t *testing.T) {
+	setupConnection(t)
+	defer Default.Conn.Close()
+
+	Default.MaxOids = 1
+
+	var err error
+	oids := []string{".1.3.6.1.2.1.1.7.0",
+		".1.3.6.1.2.1.2.2.1.10.1"} // 2 arbitrary Oids
+	errString := "oid count (2) is greater than MaxOids (1)"
+
+	_, err = Default.Get(oids)
+	if err == nil {
+		t.Fatalf("Expected too many oids failure. Got nil")
+	} else if err.Error() != errString {
+		t.Fatalf("Expected too many oids failure. Got => %v", err)
+	}
+
+	_, err = Default.GetNext(oids)
+	if err == nil {
+		t.Fatalf("Expected too many oids failure. Got nil")
+	} else if err.Error() != errString {
+		t.Fatalf("Expected too many oids failure. Got => %v", err)
+	}
+
+	_, err = Default.GetBulk(oids, 0, 0)
+	if err == nil {
+		t.Fatalf("Expected too many oids failure. Got nil")
+	} else if err.Error() != errString {
+		t.Fatalf("Expected too many oids failure. Got => %v", err)
+	}
+}
+
 func TestGenericFailureUnknownHost(t *testing.T) {
 	unknownHost := fmt.Sprintf("gosnmp-test-unknown-host-%d", time.Now().UTC().UnixNano())
 	Default.Target = unknownHost

--- a/gosnmp.go
+++ b/gosnmp.go
@@ -22,11 +22,11 @@ import (
 )
 
 const (
-	// maxOids is the maximum number of oids allowed in a Get()
-	maxOids = 60
-
 	// Base OID for MIB-2 defined SNMP variables
 	baseOid = ".1.3.6.1.2.1"
+
+	// Default MaxOids value, 60 is reasonable
+	maxOids = 60
 
 	// Java SNMP uses 50, snmp-net uses 10
 	defaultMaxRepetitions = 50
@@ -78,6 +78,10 @@ type GoSNMP struct {
 	// Conn is net connection to use, typically establised using GoSNMP.Connect()
 	Conn net.Conn
 
+	// MaxOids is the maximum number of oids allowed in a Get()
+	// (default: 60)
+	MaxOids int
+
 	// MaxRepetitions sets the GETBULK max-repetitions used by BulkWalk*
 	// (default: 50)
 	MaxRepetitions int
@@ -101,6 +105,7 @@ var Default = &GoSNMP{
 	Version:   Version2c,
 	Timeout:   time.Duration(2) * time.Second,
 	Retries:   3,
+	MaxOids:   60,
 }
 
 // SnmpPDU will be used when doing SNMP Set's
@@ -181,6 +186,12 @@ func (x *GoSNMP) Connect() error {
 		x.loggingEnabled = true
 	}
 
+	if x.MaxOids == 0 {
+		x.MaxOids = maxOids
+	} else if x.MaxOids < 0 {
+		return fmt.Errorf("MaxOids cannot be less than 0")
+	}
+
 	addr := net.JoinHostPort(x.Target, strconv.Itoa(int(x.Port)))
 	var err error
 	x.Conn, err = net.DialTimeout("udp", addr, x.Timeout)
@@ -250,9 +261,9 @@ func (x *GoSNMP) mkSnmpPacket(pdutype PDUType, nonRepeaters uint8, maxRepetition
 // Get sends an SNMP GET request
 func (x *GoSNMP) Get(oids []string) (result *SnmpPacket, err error) {
 	oidCount := len(oids)
-	if oidCount > maxOids {
-		return nil, fmt.Errorf("oid count (%d) is greater than maxOids (%d)",
-			oidCount, maxOids)
+	if oidCount > x.MaxOids {
+		return nil, fmt.Errorf("oid count (%d) is greater than MaxOids (%d)",
+			oidCount, x.MaxOids)
 	}
 	// convert oids slice to pdu slice
 	var pdus []SnmpPDU
@@ -279,9 +290,9 @@ func (x *GoSNMP) Set(pdus []SnmpPDU) (result *SnmpPacket, err error) {
 // GetNext sends an SNMP GETNEXT request
 func (x *GoSNMP) GetNext(oids []string) (result *SnmpPacket, err error) {
 	oidCount := len(oids)
-	if oidCount > maxOids {
-		return nil, fmt.Errorf("oid count (%d) is greater than maxOids (%d)",
-			oidCount, maxOids)
+	if oidCount > x.MaxOids {
+		return nil, fmt.Errorf("oid count (%d) is greater than MaxOids (%d)",
+			oidCount, x.MaxOids)
 	}
 
 	// convert oids slice to pdu slice
@@ -299,9 +310,9 @@ func (x *GoSNMP) GetNext(oids []string) (result *SnmpPacket, err error) {
 // GetBulk sends an SNMP GETBULK request
 func (x *GoSNMP) GetBulk(oids []string, nonRepeaters uint8, maxRepetitions uint8) (result *SnmpPacket, err error) {
 	oidCount := len(oids)
-	if oidCount > maxOids {
-		return nil, fmt.Errorf("oid count (%d) is greater than maxOids (%d)",
-			oidCount, maxOids)
+	if oidCount > x.MaxOids {
+		return nil, fmt.Errorf("oid count (%d) is greater than MaxOids (%d)",
+			oidCount, x.MaxOids)
 	}
 
 	// convert oids slice to pdu slice

--- a/gosnmp.go
+++ b/gosnmp.go
@@ -90,6 +90,8 @@ type GoSNMP struct {
 	requestID uint32
 	random    *rand.Rand
 
+	rxBuf *[rxBufSize]byte // has to be pointer due to https://github.com/golang/go/issues/11728
+
 	// Internal - used to sync requests to responses - snmpv3
 	msgID uint32
 }
@@ -195,6 +197,8 @@ func (x *GoSNMP) Connect() error {
 	x.msgID = uint32(x.random.Int31())
 	// RequestID is Integer32 from SNMPV2-SMI and uses all 32 bits
 	x.requestID = x.random.Uint32()
+
+	x.rxBuf = new([rxBufSize]byte)
 
 	if x.Version == Version3 {
 		x.MsgFlags |= Reportable // tell the snmp server that a report PDU MUST be sent

--- a/gosnmp.go
+++ b/gosnmp.go
@@ -85,7 +85,7 @@ type GoSNMP struct {
 	MaxOids int
 
 	// MaxRepetitions sets the GETBULK max-repetitions used by BulkWalk*
-	// (default: 50)
+	// (default: 50) TODO fix "magic number", should this be defaultMaxRepetitions?
 	MaxRepetitions int
 
 	// NonRepeaters sets the GETBULK max-repeaters used by BulkWalk*

--- a/gosnmp.go
+++ b/gosnmp.go
@@ -22,11 +22,13 @@ import (
 )
 
 const (
+	// Default MaxOids value; too many can cause remote devices to fail
+	// strangely. 60 seems to be a common value that works, but you will
+	// want to change this in the GoSNMP struct
+	MaxOids = 60
+
 	// Base OID for MIB-2 defined SNMP variables
 	baseOid = ".1.3.6.1.2.1"
-
-	// Default MaxOids value, 60 is reasonable
-	maxOids = 60
 
 	// Java SNMP uses 50, snmp-net uses 10
 	defaultMaxRepetitions = 50
@@ -79,7 +81,7 @@ type GoSNMP struct {
 	Conn net.Conn
 
 	// MaxOids is the maximum number of oids allowed in a Get()
-	// (default: 60)
+	// (default: MaxOids)
 	MaxOids int
 
 	// MaxRepetitions sets the GETBULK max-repetitions used by BulkWalk*
@@ -105,7 +107,7 @@ var Default = &GoSNMP{
 	Version:   Version2c,
 	Timeout:   time.Duration(2) * time.Second,
 	Retries:   3,
-	MaxOids:   60,
+	MaxOids:   MaxOids,
 }
 
 // SnmpPDU will be used when doing SNMP Set's
@@ -187,7 +189,7 @@ func (x *GoSNMP) Connect() error {
 	}
 
 	if x.MaxOids == 0 {
-		x.MaxOids = maxOids
+		x.MaxOids = MaxOids
 	} else if x.MaxOids < 0 {
 		return fmt.Errorf("MaxOids cannot be less than 0")
 	}

--- a/gosnmp.go
+++ b/gosnmp.go
@@ -145,27 +145,28 @@ const (
 
 // SNMPError is the type for standard SNMP errors.
 type SNMPError uint8
+
 // SNMP Errors
 const (
-	NoError SNMPError   = iota  // No error occurred. This code is also used in all request PDUs, since they have no error status to report.
-	TooBig                      // The size of the Response-PDU would be too large to transport.
-	NoSuchName                  // The name of a requested object was not found.
-	BadValue                    // A value in the request didn't match the structure that the recipient of the request had for the object. For example, an object in the request was specified with an incorrect length or type.
-	ReadOnly                    // An attempt was made to set a variable that has an Access value indicating that it is read-only.
-	GenErr                      // An error occurred other than one indicated by a more specific error code in this table.
-	NoAccess                    // Access was denied to the object for security reasons.
-	WrongType                   // The object type in a variable binding is incorrect for the object.
-	WrongLength                 // A variable binding specifies a length incorrect for the object.
-	WrongEncoding               // A variable binding specifies an encoding incorrect for the object.
-	WrongValue                  // The value given in a variable binding is not possible for the object.
-	NoCreation                  // A specified variable does not exist and cannot be created.
-	InconsistentValue           // A variable binding specifies a value that could be held by the variable but cannot be assigned to it at this time.
-	ResourceUnavailable         // An attempt to set a variable required a resource that is not available.
-	CommitFailed                // An attempt to set a particular variable failed.
-	UndoFailed                  // An attempt to set a particular variable as part of a group of variables failed, and the attempt to then undo the setting of other variables was not successful.
-	AuthorizationError          // A problem occurred in authorization.
-	NotWritable                 // The variable cannot be written or created.
-	InconsistentName            // The name in a variable binding specifies a variable that does not exist.
+	NoError             SNMPError = iota // No error occurred. This code is also used in all request PDUs, since they have no error status to report.
+	TooBig                               // The size of the Response-PDU would be too large to transport.
+	NoSuchName                           // The name of a requested object was not found.
+	BadValue                             // A value in the request didn't match the structure that the recipient of the request had for the object. For example, an object in the request was specified with an incorrect length or type.
+	ReadOnly                             // An attempt was made to set a variable that has an Access value indicating that it is read-only.
+	GenErr                               // An error occurred other than one indicated by a more specific error code in this table.
+	NoAccess                             // Access was denied to the object for security reasons.
+	WrongType                            // The object type in a variable binding is incorrect for the object.
+	WrongLength                          // A variable binding specifies a length incorrect for the object.
+	WrongEncoding                        // A variable binding specifies an encoding incorrect for the object.
+	WrongValue                           // The value given in a variable binding is not possible for the object.
+	NoCreation                           // A specified variable does not exist and cannot be created.
+	InconsistentValue                    // A variable binding specifies a value that could be held by the variable but cannot be assigned to it at this time.
+	ResourceUnavailable                  // An attempt to set a variable required a resource that is not available.
+	CommitFailed                         // An attempt to set a particular variable failed.
+	UndoFailed                           // An attempt to set a particular variable as part of a group of variables failed, and the attempt to then undo the setting of other variables was not successful.
+	AuthorizationError                   // A problem occurred in authorization.
+	NotWritable                          // The variable cannot be written or created.
+	InconsistentName                     // The name in a variable binding specifies a variable that does not exist.
 )
 
 //

--- a/gosnmp_api_test.go
+++ b/gosnmp_api_test.go
@@ -29,6 +29,7 @@ func TestAPIConfigTypes(t *testing.T) {
 	g.Timeout = time.Duration(0)
 	g.Retries = 0
 	g.Logger = log.New(ioutil.Discard, "", 0)
+	g.MaxOids = 0
 	g.MaxRepetitions = 0
 	g.NonRepeaters = 0
 

--- a/helper.go
+++ b/helper.go
@@ -242,7 +242,9 @@ func (x *GoSNMP) dumpBytes1(data []byte, msg string, maxlength int) {
 		}
 	}
 	buffer.WriteString("\n")
-	x.Logger.Print(buffer.String())
+	if x.loggingEnabled {
+		x.Logger.Print(buffer.String())
+	}
 }
 
 // dump bytes in one row, up to about screen width. Returns a string

--- a/marshal.go
+++ b/marshal.go
@@ -1131,7 +1131,7 @@ func (x *GoSNMP) unmarshal(packet []byte, response *SnmpPacket) error {
 	requestType := PDUType(packet[cursor])
 	switch requestType {
 	// known, supported types
-	case GetResponse, GetNextRequest, GetBulkRequest, Report:
+	case GetResponse, GetNextRequest, GetBulkRequest, Report, SNMPV2Trap:
 		response, err = x.unmarshalResponse(packet[cursor:], response, length, requestType)
 		if err != nil {
 			return fmt.Errorf("Error in unmarshalResponse: %s", err.Error())

--- a/trap.go
+++ b/trap.go
@@ -1,0 +1,72 @@
+// Copyright 2012-2016 The GoSNMP Authors. All rights reserved.  Use of this
+// source code is governed by a BSD-style license that can be found in the
+// LICENSE file.
+
+package gosnmp
+
+import (
+	"log"
+	"net"
+)
+
+// A TrapListener defineds parameters for running a SNMP Trap receiver.
+// nil values will be replaced by default values.
+type TrapListener struct {
+	OnNewTrap func(s *SnmpPacket, u *net.UDPAddr)
+	Params    *GoSNMP
+}
+
+// Listen listens on the UDP address addr and calls the OnNewTrap
+// function specified in *TrapListener for every trap recieved.
+func (t *TrapListener) Listen(addr string) (err error) {
+	if t.Params == nil {
+		t.Params = Default
+	}
+
+	if t.OnNewTrap == nil {
+		t.OnNewTrap = debugTrapHandler
+	}
+
+	udpAddr, err := net.ResolveUDPAddr("udp", addr)
+	if err != nil {
+		return err
+	}
+
+	conn, err := net.ListenUDP("udp", udpAddr)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	for {
+		var buf [4096]byte
+		rlen, remote, err := conn.ReadFromUDP(buf[:])
+		if err != nil {
+			if t.Params.loggingEnabled {
+				t.Params.Logger.Printf("TrapListener: error in read %s\n", err)
+			}
+		}
+
+		msg := buf[:rlen]
+		traps := t.Params.unmarshalTrap(msg)
+		t.OnNewTrap(traps, remote)
+	}
+}
+
+// Default trap handler
+func debugTrapHandler(s *SnmpPacket, u *net.UDPAddr) {
+	log.Printf("got trapdata from %+v: %+v\n", u, s)
+}
+
+// Unmarshal SNMP Trap
+func (x *GoSNMP) unmarshalTrap(trap []byte) (result *SnmpPacket) {
+	result = new(SnmpPacket)
+	err := x.unmarshal(trap, result)
+	if err != nil {
+		if x.loggingEnabled {
+			x.Logger.Printf("unmarshalTrap: %s\n", err)
+		}
+	}
+
+	return result
+}


### PR DESCRIPTION
package main

import (
    g "github.com/soniah/gosnmp"
    "time"
    "fmt"
)

func main() {

```
params := &g.GoSNMP{
        Target:     "1.1.1.1",
        Port:       161,
        Community:  cunit,
        Version:    g.Version2c,
        Timeout:    time.Duration(5) * time.Second,
        Retries:    2,
}
err := params.Connect()
fmt.Println(err)
defer params.Conn.Close()
```

}

Connection fails, it does not return an error message. But returns nil. This is a bug
